### PR TITLE
Fixing #7 by adding initial `setup_highlights` call

### DIFF
--- a/lua/tiny-inline-diagnostic/init.lua
+++ b/lua/tiny-inline-diagnostic/init.lua
@@ -41,8 +41,12 @@ function M.setup(opts)
     end
 
     local config = vim.tbl_deep_extend("force", default_config, opts)
-
-    hi.setup_highlights(config.blend, config.hi)
+    vim.api.nvim_create_autocmd("ColorScheme", {
+        pattern = "*",
+        callback = function()
+            hi.setup_highlights(config.blend, config.hi)
+        end
+    })
     diag.set_diagnostic_autocmds(config)
 end
 

--- a/lua/tiny-inline-diagnostic/init.lua
+++ b/lua/tiny-inline-diagnostic/init.lua
@@ -41,6 +41,7 @@ function M.setup(opts)
     end
 
     local config = vim.tbl_deep_extend("force", default_config, opts)
+    hi.setup_highlights(config.blend, config.hi)
     vim.api.nvim_create_autocmd("ColorScheme", {
         pattern = "*",
         callback = function()


### PR DESCRIPTION
PR #5 broke colors (#7) for users who don't change their color scheme (and or change it before setting up this plugin). This PR adds an initial `setup_highlights` call to fix this. 