### PR TITLE
Fix diagnostics readability on light backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,5 @@ require('tiny-inline-diagnostic').setup({
     - If you have no background color, you should try to set `blend.mixing_color` to a color that will blend with the background color.
 - **Q**: All diagnostics are still displayed
     - You need to set `vim.diagnostic.config({ virtual_text = false })` to remove all the others diagnostics.
+- **Q**: Diagnostics are not readable on a light background
+    - You can either set `vim.g.background = "light"` to use white diagnostics background. Will not work if `blend.mixing_color` is set

--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ require('tiny-inline-diagnostic').setup({
 - **Q**: All diagnostics are still displayed
     - You need to set `vim.diagnostic.config({ virtual_text = false })` to remove all the others diagnostics.
 - **Q**: Diagnostics are not readable on a light background
-    - You can either set `vim.g.background = "light"` to use white diagnostics background. Will not work if `blend.mixing_color` is set
+    - You can either set `vim.g.background = "light"` to use white diagnostics background. Will not work if `hi.mixing_color` is set

--- a/lua/tiny-inline-diagnostic/highlights.lua
+++ b/lua/tiny-inline-diagnostic/highlights.lua
@@ -32,8 +32,12 @@ function M.setup_highlights(blend, default_hi)
         colors.background = get_hi(default_hi.background).bg
     end
 
-    if default_hi.mixing_colors == "None" then
-        colors.mixing_color = "#000000"
+    if default_hi.mixing_color == "None" then
+        if vim.g.background == "light" then
+            colors.mixing_color = "#ffffff"
+        else
+            colors.mixing_color = "#000000"
+        end
     else
         colors.mixing_color = default_hi.mixing_color
     end


### PR DESCRIPTION
wanted to use this plugin but i'm using a light background, here's what i saw after i installed the plugin
![Screenshot from 2024-07-06 11-49-54](https://github.com/rachartier/tiny-inline-diagnostic.nvim/assets/96741038/2f3d366c-6414-44c2-b303-b98d0da9bfee)

so although it can be fixed by setting `hi = { mixing_color = "#ffffff"  }` i thought it would be neat if this could be set automatically when light background is enabled. when i looked into the source code, i found a bug too, in the `if` statement, there is `default_hi.mixing_colors` instead if `default_hi.mixing_color`