### PR TITLE
fix: make background highlight extend through the whole line

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ require("tiny-inline-diagnostic").setup({
 ```
 
 ## 💡 Highlights
-
+- TinyInlineDiagnosticVirtualTextBg
 - TinyInlineDiagnosticVirtualTextError
 - TinyInlineDiagnosticVirtualTextWarn
 - TinyInlineDiagnosticVirtualTextInfo

--- a/lua/tiny-inline-diagnostic/extmarks.lua
+++ b/lua/tiny-inline-diagnostic/extmarks.lua
@@ -99,7 +99,7 @@ function M.create_extmarks(opts, event, curline, virt_lines, offset, need_to_be_
 
 		vim.api.nvim_buf_set_extmark(event.buf, diagnostic_ns, curline, 0, {
 			id = curline + 1000,
-			line_hl_group = "CursorLine",
+			line_hl_group = "TinyInlineDiagnosticVirtualTextBg",
 			virt_text_pos = "eol",
 			virt_text = virt_lines[1],
 			virt_lines = v,
@@ -115,7 +115,7 @@ function M.create_extmarks(opts, event, curline, virt_lines, offset, need_to_be_
 	if need_to_be_under then
 		vim.api.nvim_buf_set_extmark(event.buf, diagnostic_ns, curline + 1, 0, {
 			id = get_uuid(),
-			line_hl_group = "CursorLine",
+			line_hl_group = "TinyInlineDiagnosticVirtualTextBg",
 			virt_text_pos = "overlay",
 			virt_text_win_col = 0,
 			virt_text = virt_lines[2],
@@ -141,7 +141,7 @@ function M.create_extmarks(opts, event, curline, virt_lines, offset, need_to_be_
 
 		vim.api.nvim_buf_set_extmark(event.buf, diagnostic_ns, curline, 0, {
 			id = get_uuid(),
-			line_hl_group = "CursorLine",
+			line_hl_group = "TinyInlineDiagnosticVirtualTextBg",
 			virt_text_pos = "overlay",
 			virt_text = virt_lines[1],
 			virt_lines = other_virt_lines,
@@ -152,7 +152,7 @@ function M.create_extmarks(opts, event, curline, virt_lines, offset, need_to_be_
 	else
 		vim.api.nvim_buf_set_extmark(event.buf, diagnostic_ns, curline, 0, {
 			id = get_uuid(),
-			line_hl_group = "CursorLine",
+			line_hl_group = "TinyInlineDiagnosticVirtualTextBg",
 			virt_text_pos = "eol",
 			virt_text = virt_lines[1],
 			-- virt_text_win_col = win_col + offset,

--- a/lua/tiny-inline-diagnostic/highlights.lua
+++ b/lua/tiny-inline-diagnostic/highlights.lua
@@ -55,6 +55,7 @@ function M.setup_highlights(blend, default_hi)
 	}
 
 	local hi = {
+		TinyInlineDiagnosticVirtualTextBg = { bg = colors.background },
 		TinyInlineDiagnosticVirtualTextError = { bg = blends.error, fg = colors.error.fg, italic = colors.error.italic },
 		TinyInlineDiagnosticVirtualTextWarn = { bg = blends.warn, fg = colors.warn.fg, italic = colors.warn.italic },
 		TinyInlineDiagnosticVirtualTextInfo = { bg = blends.info, fg = colors.info.fg, italic = colors.info.italic },


### PR DESCRIPTION
makes `hi.background` extend through the whole line, which i believe is the expected behaviour. it seemed strange to me that changing it only changed the background of the diagnostic itself, and that there was no way to change the highlight of the remaining part from `CursorLine`. 