### PR TITLE
fix: padding for multibytes characters in virtual text

### DIFF
--- a/lua/tiny-inline-diagnostic/chunk.lua
+++ b/lua/tiny-inline-diagnostic/chunk.lua
@@ -11,8 +11,9 @@ function M.get_max_width_from_chunks(chunks)
 	local max_chunk_line_length = 0
 
 	for i = 1, #chunks do
-		if #chunks[i] > max_chunk_line_length then
-			max_chunk_line_length = #chunks[i]
+		local line_length = vim.fn.strdisplaywidth(chunks[i])
+		if line_length > max_chunk_line_length then
+			max_chunk_line_length = line_length
 		end
 	end
 

--- a/lua/tiny-inline-diagnostic/virtual_text.lua
+++ b/lua/tiny-inline-diagnostic/virtual_text.lua
@@ -27,7 +27,7 @@ function M.from_diagnostic(opts, ret, index_diag, padding, total_chunks)
 	for index_chunk = 1, #chunks do
 		local message = utils.trim(chunks[index_chunk])
 
-		local to_add = padding - #message
+		local to_add = padding - vim.fn.strdisplaywidth(message)
 		message = message .. string.rep(" ", to_add)
 
 		if index_chunk == 1 then


### PR DESCRIPTION
Hello. Thanks for the nice plugin!

I am using Neovim in a Japanese environment and I have confirmed that if the diagnosic results contain multibyte characters, the virtual text is not padded correctly and the display is messed up.

Using `vim.fn.strdisplaywidth` to count the number of characters seems to have solved this problem, so I will send a PR.

There may be other omissions, so it would be great if you could check and merge them in.

Before:
![image](https://github.com/user-attachments/assets/4c209845-ed8b-4e3b-b130-d14045c45e08)

After:
![image](https://github.com/user-attachments/assets/4debe1c8-c409-4594-bba6-99dc7cd74cf1)
