### PR TITLE
Remove print statement on detach buffer

### DIFF
--- a/lua/tiny-inline-diagnostic/diagnostic.lua
+++ b/lua/tiny-inline-diagnostic/diagnostic.lua
@@ -152,7 +152,6 @@ end
 
 ---@param buf number
 local function detach_buffer(buf)
-	print("Detaching buffer", buf)
 	timers.close(buf)
 	attached_buffers[buf] = nil
 end


### PR DESCRIPTION
Looks like a print statement was left in.