### PR TITLE
Update README.md about `get_diagnostic_under_cursor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ require("tiny-inline-diagnostic").setup({
 ## 📚 API
 
 - `require("tiny-inline-diagnostic").change(blend, highlights)`: change the colors of the diagnostic. You need to refer to `setup` to see the structure of the `blend` and `highlights` options.
-- `require("tiny-inline-diagnostic").get_diagnostic_under_cursor(bufnr)`: get the diagnostic under the cursor, useful if you want to display the diagnostic in a statusline.
+- `require("tiny-inline-diagnostic").get_diagnostic_under_cursor()`: get the diagnostic under the cursor, useful if you want to display the diagnostic in a statusline.
 - `require("tiny-inline-diagnostic").enable()`: enable the diagnostic.
 - `require("tiny-inline-diagnostic").disable()`: disable the diagnostic.
 - `require("tiny-inline-diagnostic").toggle()`: toggle the diagnostic, on/off.


### PR DESCRIPTION
#95 
Thank you for fixing it.
However, I noticed that the new function doesn't require bufnr to be passed as a parameter, 
so I updated the README to avoid confusion for others.