### PR TITLE
add 'padding' option to overflow options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ require("tiny-inline-diagnostic").setup({
             -- "none" - Do not truncate messages
             -- "oneline" - Keep the message on a single line, even if it's long
             mode = "wrap",
+
+            -- Trigger wrapping to occur this many characters earlier when mode == "wrap".
+            -- Increase this value appropriately if you notice that the last few characters
+            -- of wrapped diagnostics are sometimes obscured.
+            padding = 0,
         },
 
         -- Configuration for breaking long messages into separate lines

--- a/lua/tiny-inline-diagnostic/chunk.lua
+++ b/lua/tiny-inline-diagnostic/chunk.lua
@@ -295,6 +295,7 @@ function M.handle_overflow_modes(opts, diag_message, need_to_be_under, win_width
 			local ok, win_col = pcall(vim.fn.virtcol, "$")
 			offset = ok and win_col or 0
 		end
+		offset = (opts.options.overflow.padding or 0) + offset
 		chunks = M.get_message_chunks_for_overflow(diag_message, offset, win_width, opts)
 	elseif opts.options.overflow.mode == "none" then
 		chunks = utils.wrap_text(diag_message, 0)


### PR DESCRIPTION
When the preset is set to something where the left sign is `""` (`classic`, `simple`, `minimal`, and `transparent_bg=true`),  the last few characters at the end of wrapped lines are sometimes cut off:

This PR adds `padding` as an overflow option, so wrapping can be triggered earlier, getting around this issue.

Before:
![nvim0](https://github.com/user-attachments/assets/188650fc-fa30-4730-8bd8-464731cd05d8)

After (`padding = 2`):
![nvim1](https://github.com/user-attachments/assets/afd13a7d-41b2-4135-a099-c7edf34d1def)

Changing the presets in `presets.lua` to use a space character instead of `""` doesn't work. Setting the left sign to an invisible unicode character works, but then there is an unsatisfying 'gap' on the left, as the invisible character does not take on the cursor colour.

It might be to something do with my config, such as the diagnostic symbols in the sign column. I think having the padding option is good for finetuning.