### PR TITLE
feat: added if_many option for show_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ require("tiny-inline-diagnostic").setup({
 
     options = {
         -- Display the source of the diagnostic (e.g., basedpyright, vsserver, lua_ls etc.)
-        show_source = false,
+	show_source = {
+	    enabled = false,
+	    if_many = false,
+	},
 
         -- Use icons defined in the diagnostic configuration
         use_icons_from_diagnostic = false,

--- a/doc/tiny-inline-diagnostic.nvim.txt
+++ b/doc/tiny-inline-diagnostic.nvim.txt
@@ -86,7 +86,10 @@ OPTIONS      *tiny-inline-diagnostic.nvim-tiny-inline-diagnostic.nvim-options*
     
         options = {
             -- Display the source of the diagnostic (e.g., basedpyright, vsserver, lua_ls etc.)
-            show_source = false,
+	    show_source = {
+		    enabled = false,
+		    if_many = false,
+	    },
     
             -- Use icons defined in the diagnostic configuration
             use_icons_from_diagnostic = false,

--- a/lua/tiny-inline-diagnostic/chunk.lua
+++ b/lua/tiny-inline-diagnostic/chunk.lua
@@ -244,7 +244,26 @@ function M.get_chunks(opts, diags_on_line, diag_index, diag_line, cursor_line, b
 
 	local diag = diags_on_line[diag_index]
 
-	if opts.options.show_source and diag.source then
+	local show_source = false
+	if type(opts.options.show_source) == "table" then
+		if opts.options.show_source.enabled then
+			if opts.options.show_source.if_many then
+				local sources = {}
+				for _, d in ipairs(diags_on_line) do
+					if d.source then
+						sources[d.source] = true
+					end
+				end
+				show_source = vim.tbl_count(sources) > 1
+			else
+				show_source = true
+			end
+		end
+	elseif opts.options.show_source then
+		show_source = true
+	end
+
+	if show_source and diag.source then
 		diag.message = diag.message .. " (" .. diag.source .. ")"
 	end
 

--- a/lua/tiny-inline-diagnostic/init.lua
+++ b/lua/tiny-inline-diagnostic/init.lua
@@ -24,7 +24,10 @@ local default_config = {
 		mixing_color = "Normal",
 	},
 	options = {
-		show_source = false,
+		show_source = {
+			enabled = false,
+			if_many = false,
+		},
 		add_messages = true,
 		set_arrow_to_diag_color = false,
 		use_icons_from_diagnostic = false,


### PR DESCRIPTION
# Show diagnostic sources only when there are multiple sources

This PR adds a new configuration option `if_many` to the `show_source` setting that allows showing diagnostic sources only when there are multiple different sources on the same line.

## Changes
- Added `if_many` option to `show_source` configuration
- Updated default configuration to support table-based settings
- Maintained backward compatibility with boolean `show_source` option so show_source = true will also keep working
- Updated Docs and readme accordingly

## Configuration

Users can now configure source display in two ways:

```lua
-- Old style (backward compatible)
{
  options = {
    show_source = true  -- or false
  }
}

-- New style
{
  options = {
    show_source = {
      enabled = true,  -- enable showing sources
      if_many = true   -- only show when multiple different sources exist
    }
  }
}
