### PR TITLE
[feat] don't show subsequent whitespaces without line breaks

### DIFF
--- a/lua/tiny-inline-diagnostic/extmarks.lua
+++ b/lua/tiny-inline-diagnostic/extmarks.lua
@@ -99,10 +99,16 @@ end
 local function create_multiline_extmark(buf, curline, virt_lines, priority)
 	local remaining_lines = { unpack(virt_lines, 2) }
 
+  local virt_lines_trimmed = {}
+  for i, t in ipairs(virt_lines[1]) do
+    local ktrimmed = t[1]:gsub('%s+', ' ')
+    virt_lines_trimmed[i] = {ktrimmed, t[2]}
+  end
+
 	vim.api.nvim_buf_set_extmark(buf, DIAGNOSTIC_NAMESPACE, curline, 0, {
 		id = generate_uid(),
 		virt_text_pos = "eol",
-		virt_text = virt_lines[1],
+		virt_text = virt_lines_trimmed,
 		virt_lines = remaining_lines,
 		priority = priority,
 		strict = false,


### PR DESCRIPTION
- when there are line breaks in a diagnostic, don't show them when the diagnostic is placed on a single line
- this is useful for diagnostics providers that use line breaks in their diagnostics, especially so, if they indent the diagnostics on the next line. It also removes the ugly `^@` that stands for linebreaks