### PR TITLE
fix(cache): clear cache when diagnostics are empty to avoid stale err…

### DIFF
--- a/lua/tiny-inline-diagnostic/cache.lua
+++ b/lua/tiny-inline-diagnostic/cache.lua
@@ -26,6 +26,12 @@ function M.update(opts, bufnr, diagnostics)
     diagnostics = vim.diagnostic.get(bufnr)
   end
 
+  -- Fix: Clear cache when diagnostics are empty to avoid displaying stale errors
+  if vim.tbl_isempty(diagnostics) then
+    diagnostics_cache[bufnr] = {}
+    return
+  end
+
   local diag_buf = diagnostics_cache[bufnr] or {}
 
   local namespaces = {}


### PR DESCRIPTION
Fixes issue where stale diagnostic errors remain visible even after the underlying LSP server clears them. This happens when:

1. User inputs incomplete code (e.g., unclosed parentheses)
2. LSP reports syntax error and plugin stores it in cache
3. User completes the code, LSP clears the error
4. Plugin cache should be cleared but wasn't due to empty namespaces

The fix adds an early return to clear the cache when diagnostics are empty, preventing display of outdated error messages.

---

This fix works for me.