### PR TITLE
feat: expose enabled state on main module

### DIFF
--- a/lua/tiny-inline-diagnostic/init.lua
+++ b/lua/tiny-inline-diagnostic/init.lua
@@ -77,6 +77,7 @@ local default_config = {
 }
 
 M.config = nil
+M.enabled = diag.enabled
 
 ---Create color scheme autocommand
 local function setup_colorscheme_handler(config)


### PR DESCRIPTION
Exposes `M.enabled` to allow external code to check if plugin is enabled.

## Changes
- Add `M.enabled = diag.enabled` to main module export

## Use case
Enables consumers to check enabled state without accessing internal modules.