### PR TITLE
fix: sort extmark_id when serverity are equal

### DIFF
--- a/lua/tiny-inline-diagnostic/cache.lua
+++ b/lua/tiny-inline-diagnostic/cache.lua
@@ -8,6 +8,12 @@ local function sort_by_severity(diagnostics)
   local sorted = vim.deepcopy(diagnostics)
   table.sort(sorted, function(a, b)
     return a.severity < b.severity
+      or (
+        a.severity == b.severity
+        and a._extmark_id
+        and b._extmark_id
+        and a._extmark_id > b._extmark_id
+      )
   end)
   return sorted
 end


### PR DESCRIPTION
`nvim --clean --cmd 'set rtp^=.' repro.lua +11`, `:so<cr>`

Since lua sort is non-stable, which means when their severity are equal, the order is random, this PR make new created extmark have higher priority (IIUC)
```lua
require("tiny-inline-diagnostic").setup({})
-- vim.diagnostic.config({ severity_sort = false, virtual_lines = { current_line = true }, virtual_text = true })
local ns = vim.api.nvim_create_namespace("test_stable_diag")
local bufnr = vim.api.nvim_get_current_buf()

-- local m = vim.v.maxcol
local m = 100
local l = 10
local diagnostics = {
	{ end_col = m, col = 0, lnum = l, message = "a", severity = 2 },
	{ end_col = m, col = 0, lnum = l, message = "b", severity = 2 },
	{ end_col = m, col = 0, lnum = l, message = "c", severity = 2 },
	{ end_col = m, col = 0, lnum = 20, message = "d", severity = 2 },
	{ end_col = m, col = 0, lnum = 20, message = "e", severity = 2 },
	{ end_col = m, col = 0, lnum = 20, message = "f", severity = 2 },
}

vim.diagnostic.set(ns, bufnr, diagnostics, {})
-- vim.diagnostic.show(ns, bufnr)
vim.diagnostic.open_float()
vim.api.nvim_exec_autocmds("LspAttach", {})

local shown = vim.diagnostic.get(bufnr)
print("Order of diagnostics at lnum=0:")
for i, d in ipairs(shown) do
	print(i, d.message)
end
```
