### PR TITLE
fix: ensure the new logic is used for the cursorline visibility check

### DIFF
--- a/lua/tiny-inline-diagnostic/highlights.lua
+++ b/lua/tiny-inline-diagnostic/highlights.lua
@@ -144,7 +144,7 @@ end
 function M.get_diagnostic_highlights(blend_factor, diag_ret, curline, index_diag)
   local diag_hi, diag_inv_hi, body_hi = M.get_diagnostic_highlights_from_severity(diag_ret.severity)
 
-  local is_cursorline_enabled = vim.opt.cursorline:get()
+  local cursorline_is_visible = is_cursorline_visible()
 
   if
     (diag_ret.line and diag_ret.line == curline)
@@ -161,7 +161,7 @@ function M.get_diagnostic_highlights(blend_factor, diag_ret, curline, index_diag
     (diag_ret.line and diag_ret.line ~= curline)
     or index_diag > 1
     or diag_ret.need_to_be_under
-    or not is_cursorline_enabled
+    or not cursorline_is_visible
   then
     diag_inv_hi = diag_inv_hi .. "NoBg"
   end


### PR DESCRIPTION
this is very embarrassing, but in a previous commit, the logic was changed from simply checking the cursorline option to also considering the related cursorlineopt option to verify that the full cursorline is drawn and thus visible.

there is unfortunately one more spot in the code i've missed that needs to use the new logic too

i'm terribly sorry to notice it this late, especially considering that the original pr was just merged