### PR TITLE
Add option to show diagnostic code for diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ require("tiny-inline-diagnostic").setup({
             if_many = false,           -- Only show source if multiple sources exist for the same diagnostic
         },
 
+        -- Display the diagnostic code of diagnostics (e.g., "F401", "no-dupe-args")
+        show_code = true,
+
         -- Use icons from vim.diagnostic.config instead of preset icons
         use_icons_from_diagnostic = false,
 

--- a/doc/tiny-inline-diagnostic.nvim.txt
+++ b/doc/tiny-inline-diagnostic.nvim.txt
@@ -186,6 +186,9 @@ CONFIGURATION*tiny-inline-diagnostic.nvim-tiny-inline-diagnostic.nvim-configurat
                 enabled = false,           -- Enable showing source names
                 if_many = false,           -- Only show source if multiple sources exist for the same diagnostic
             },
+
+            -- Display the diagnostic code of diagnostics (e.g., "F401", "no-dupe-args")
+            show_code = true,
     
             -- Use icons from vim.diagnostic.config instead of preset icons
             use_icons_from_diagnostic = false,

--- a/lua/tiny-inline-diagnostic/chunk.lua
+++ b/lua/tiny-inline-diagnostic/chunk.lua
@@ -411,6 +411,8 @@ function M.get_chunks(opts, diags_on_line, diag_index, diag_line, cursor_line, b
     show_source = true
   end
 
+  local show_code = opts.options.show_code
+
   local diag_message = diag.message
   if diag.is_related then
     local location_info = ""
@@ -426,8 +428,13 @@ function M.get_chunks(opts, diags_on_line, diag_index, diag_line, cursor_line, b
       end
     end
     diag_message = diag_message .. location_info
-  elseif show_source and diag.source then
-    diag_message = diag_message .. " (" .. diag.source .. ")"
+  else
+    if show_code and diag.code then
+      diag_message = diag_message .. " [" .. diag.code .. "]"
+    end
+    if show_source and diag.source then
+      diag_message = diag_message .. " (" .. diag.source .. ")"
+    end
   end
 
   local chunks = { diag_message }

--- a/lua/tiny-inline-diagnostic/init.lua
+++ b/lua/tiny-inline-diagnostic/init.lua
@@ -28,6 +28,7 @@ local default_config = {
       enabled = false,
       if_many = false,
     },
+    show_code = true,
     show_related = {
       enabled = true,
       max_count = 3,

--- a/tests/test_chunk.lua
+++ b/tests/test_chunk.lua
@@ -288,6 +288,7 @@ T["get_chunks"]["returns chunk info for diagnostic"] = function()
         softwrap = 10,
         break_line = { enabled = false },
         show_source = { enabled = false },
+        show_code = false,
       },
     })
     local diags = {
@@ -312,6 +313,7 @@ T["get_chunks"]["includes source when show_source is enabled"] = function()
         softwrap = 10,
         break_line = { enabled = false },
         show_source = { enabled = true },
+        show_code = false,
       },
     })
     local diags = {
@@ -326,6 +328,35 @@ T["get_chunks"]["includes source when show_source is enabled"] = function()
     local result = chunk.get_chunks(opts, diags, 1, 0, 0, buf)
     local full_message = table.concat(result.chunks, "")
     MiniTest.expect.equality(full_message:find("test_lsp") ~= nil, true)
+    MiniTest.expect.equality(full_message:find("E308") ~= nil, false)
+  end)
+end
+
+T["get_chunks"]["includes code when show_code is enabled"] = function()
+  H.with_buf({ "test line" }, function(buf)
+    local opts = H.make_opts({
+      options = {
+        overflow = { mode = "none" },
+        multilines = { enabled = false },
+        softwrap = 10,
+        break_line = { enabled = false },
+        show_source = { enabled = true },
+        show_code = true,
+      },
+    })
+    local diags = {
+      {
+        message = "test error",
+        severity = vim.diagnostic.severity.ERROR,
+        lnum = 0,
+        source = "test_lsp",
+        code = "E308",
+      },
+    }
+
+    local result = chunk.get_chunks(opts, diags, 1, 0, 0, buf)
+    local full_message = table.concat(result.chunks, "")
+    MiniTest.expect.equality(full_message:find("%[E308%] %(test_lsp%)") ~= nil, true)
   end)
 end
 
@@ -339,6 +370,7 @@ T["get_chunks"]["sets need_to_be_under for long lines"] = function()
         softwrap = 10,
         break_line = { enabled = false },
         show_source = { enabled = false },
+        show_code = false,
       },
     })
     local diags = {
@@ -360,6 +392,7 @@ T["get_chunks"]["does not set need_to_be_under for short lines"] = function()
         softwrap = 10,
         break_line = { enabled = false },
         show_source = { enabled = false },
+        show_code = false,
       },
     })
     local diags = {
@@ -381,6 +414,7 @@ T["get_chunks"]["uses display width not byte length"] = function()
         softwrap = 5,
         break_line = { enabled = false },
         show_source = { enabled = false },
+        show_code = false,
       },
     })
     local diags = {
@@ -402,6 +436,7 @@ T["get_chunks"]["uses virtcol when cursor on diagnostic line"] = function()
         softwrap = 10,
         break_line = { enabled = false },
         show_source = { enabled = false },
+        show_code = false,
       },
     })
     local diags = {
@@ -423,6 +458,7 @@ T["get_chunks"]["accounts for window width in wrapping decision"] = function()
         softwrap = 10,
         break_line = { enabled = false },
         show_source = { enabled = false },
+        show_code = false,
       },
     })
     local diags = {
@@ -444,6 +480,7 @@ T["get_chunks"]["wraps when line exceeds window width minus softwrap"] = functio
         softwrap = 5,
         break_line = { enabled = false },
         show_source = { enabled = false },
+        show_code = false,
       },
     })
     local diags = {

--- a/tests/test_diagnostic.lua
+++ b/tests/test_diagnostic.lua
@@ -12,6 +12,7 @@ local function create_test_opts()
       use_icons_from_diagnostic = false,
       set_arrow_to_diag_color = false,
       show_source = { enabled = false },
+      show_code = false,
       overflow = { mode = "none" },
       break_line = { enabled = false },
       multilines = { enabled = false },


### PR DESCRIPTION
This matches the behavior of the built-in diagnostic display. It makes it much easier to disable specific diagnostic codes from linters and type checkers when they need to be overridden.