### PR TITLE
fix: use correct fallback mixing color for transparent bg on light themes

### DIFF
--- a/lua/tiny-inline-diagnostic/highlights.lua
+++ b/lua/tiny-inline-diagnostic/highlights.lua
@@ -64,12 +64,17 @@ end
 ---@return string
 local function get_mixing_color(color)
   if color == "None" then
-    return vim.g.background == "light" and "#ffffff" or "#000000"
+    return vim.o.background == "light" and "#ffffff" or "#000000"
   end
   if color:sub(1, 1) == "#" then
     return color
   end
-  return get_highlight(color).bg
+
+  local resolved = get_highlight(color).bg
+  if resolved == "None" then
+    return vim.o.background == "light" and "#ffffff" or "#000000"
+  end
+  return resolved
 end
 
 ---Check if the cursorline is visible


### PR DESCRIPTION
## Summary

Fixes #174

When a colorscheme sets a transparent background (`Normal` bg is `None`), `get_mixing_color()` should fall back to `#ffffff` for light themes and `#000000` for dark themes. Two bugs prevented this:

1. **`vim.g.background` instead of `vim.o.background`** — The existing fallback on line 67 used `vim.g.background` (a global *variable* that is never set) instead of `vim.o.background` (the Vim *option*). This meant the light/dark check always evaluated to `nil`/falsy, defaulting to black regardless of the actual background setting.

2. **Resolved highlight bg `"None"` not handled** — When `mixing_color` is a highlight group name (default: `"Normal"`), the function resolved the group's `bg` via `nvim_get_hl` but did not check whether the resolved value was `"None"`. The `"None"` string was passed directly to `utils.blend()`, where `hex_to_rgb("None")` returns `{0, 0, 0}` (black). This means the first bug on line 67 was actually unreachable in the default configuration — the code fell through to line 72 instead.

## Changes

- Fixed `vim.g.background` → `vim.o.background` on line 67
- Added a check for the resolved highlight bg being `"None"` after `get_highlight(color).bg`, applying the same light/dark fallback